### PR TITLE
bump react to 15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tween-functions": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "0.13 - 0.14"
+    "react": "0.13 - 15.0"
   },
   "devDependencies": {
     "babel": "^5.8.23"


### PR DESCRIPTION
The package is already compatible with React 15 so there is no need for more changes.
This commit gets rid of the warning