### PR TITLE
Make react dep range more inclusive

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tween-functions": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "0.13 - 15.0"
+    "react": "0.13 - 15"
   },
   "devDependencies": {
     "babel": "^5.8.23"


### PR DESCRIPTION
The current react version `15.1.0` does not match the range. This PR fixes that.