### PR TITLE
add tests and upgrade babel to babel 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React component to render element for scroll to top of page",
   "author": "Milos Janda <milos.janda@gmail.com>",
   "scripts": {
+    "test": "mocha --compilers js:babel-core/register test/test.jsx",
     "build": "babel scrollUp.jsx --out-file index.js",
     "prepublish": "npm run build"
   },
@@ -24,6 +25,12 @@
     "react",
     "react-component"
   ],
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ]
+  },
   "dependencies": {
     "object-assign": "^4.0.1",
     "tween-functions": "^1.1.0"
@@ -32,7 +39,17 @@
     "react": "0.13 - 15"
   },
   "devDependencies": {
-    "babel": "^5.8.23"
+    "babel-cli": "6.16.0",
+    "babel-core": "6.17.0",
+    "babel-preset-es2015": "6.16.0",
+    "babel-preset-react": "6.16.0",
+    "chai": "3.5.0",
+    "jsdom": "9.6.0",
+    "mocha": "3.1.0",
+    "raf": "3.3.0",
+    "react": "15.3.2",
+    "react-addons-test-utils": "15.3.2",
+    "sinon": "1.17.6"
   },
   "readmeFilename": "README.md",
   "license": "MIT"

--- a/scrollUp.jsx
+++ b/scrollUp.jsx
@@ -69,6 +69,7 @@ var ScrollUp = React.createClass({
     },
 
     handleScroll: function () {
+      console.log('got here')
         if (window.pageYOffset > this.props.showUnder) {
             this.setState({show: true});
         } else {

--- a/scrollUp.jsx
+++ b/scrollUp.jsx
@@ -69,7 +69,6 @@ var ScrollUp = React.createClass({
     },
 
     handleScroll: function () {
-      console.log('got here')
         if (window.pageYOffset > this.props.showUnder) {
             this.setState({show: true});
         } else {

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -19,6 +19,13 @@ describe('<ScrollUp/>', function () {
   beforeEach(function () {
     window.pageYOffset = 0
   })
+  afterEach(function () {
+    try {
+      window.scrollTo.restore()
+    } catch (err) {
+      // do nothing...
+    }
+  })
 
   // and each `it` function describes an individual test
   it('is hidden when first rendered', function () {
@@ -49,6 +56,8 @@ describe('<ScrollUp/>', function () {
         <span>UP</span>
       </ScrollUp>
     );
+    // Ensure topPosition is set correctly
+    expect(renderedComponent.props.topPosition).to.equal(0)
     // Set the scroll position to 200 and trigger the event manually
     window.pageYOffset = 200
     renderedComponent.handleScroll()
@@ -70,4 +79,33 @@ describe('<ScrollUp/>', function () {
         done()
     }, 500)
   });
+  it('scrolls to `topPosition` when clicked', function (done) {
+    var renderedComponent = TestUtils.renderIntoDocument(
+      <ScrollUp showUnder={100} topPosition={100}>
+        <span>UP</span>
+      </ScrollUp>
+    );
+    // Ensure topPosition is set correctly
+    expect(renderedComponent.props.topPosition).to.equal(100)
+    // Set the scroll position to 200 and trigger the event manually
+    window.pageYOffset = 200
+    renderedComponent.handleScroll()
+
+    // "stub" the window.scrollTo function (because we want to see how it's called)
+    var scrollToSpy = sinon.stub(window, 'scrollTo', function (x, y) {
+      window.pageXOffset = x
+      window.pageYOffset = y
+      renderedComponent.handleScroll() // And make sure to trigger the handleScroll for each call
+    })
+
+    // Now activate the click function
+    renderedComponent.handleClick()
+
+    // Give it a bit to scroll back up
+    setTimeout(function () {
+        expect(scrollToSpy.lastCall.args[1]).to.be.within(95, 105)
+        expect(renderedComponent.state.show).to.be.false
+        done()
+    }, 500)
+  })
 });

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -1,0 +1,73 @@
+// JSDom is used to allow the tests to run right from the command line (no browsers needed)
+var jsdom = require('jsdom');
+global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
+global.navigator  = window.navigator;
+// Also apply a requestAnimationFrame polyfill
+require('raf').polyfill()
+
+
+var React = require('react');
+var sinon = require('sinon');
+var expect = require('chai').expect;
+var TestUtils = require('react-addons-test-utils');
+var ScrollUp = require('../index')
+
+// describe makes a test group
+describe('<ScrollUp/>', function () {
+  // This will be run before each test to reset the scroll position
+  beforeEach(function () {
+    window.pageYOffset = 0
+  })
+
+  // and each `it` function describes an individual test
+  it('is hidden when first rendered', function () {
+    var renderedComponent = TestUtils.renderIntoDocument(
+      <ScrollUp showUnder={100}>
+        <span>UP</span>
+      </ScrollUp>
+    );
+
+    expect(renderedComponent.state.show).to.be.false
+  });
+  it('is shown if the page is scrolled past the `showUnder` point', function () {
+    var renderedComponent = TestUtils.renderIntoDocument(
+      <ScrollUp showUnder={100}>
+        <span>UP</span>
+      </ScrollUp>
+    );
+
+    // Set the scroll position to 200 and trigger the event manually
+    window.pageYOffset = 200
+    renderedComponent.handleScroll()
+
+    expect(renderedComponent.state.show).to.be.true
+  });
+  it('scrolls back up to the top when clicked', function (done) {
+    var renderedComponent = TestUtils.renderIntoDocument(
+      <ScrollUp showUnder={100}>
+        <span>UP</span>
+      </ScrollUp>
+    );
+    // Set the scroll position to 200 and trigger the event manually
+    window.pageYOffset = 200
+    renderedComponent.handleScroll()
+
+    // "stub" the window.scrollTo function (because we want to see how it's called)
+    var scrollToSpy = sinon.stub(window, 'scrollTo', function (x, y) {
+      window.pageXOffset = x
+      window.pageYOffset = y
+      renderedComponent.handleScroll() // And make sure to trigger the handleScroll for each call
+    })
+
+    // Now activate the click function
+    renderedComponent.handleClick()
+
+    // Give it a bit to scroll back up
+    setTimeout(function () {
+        expect(scrollToSpy.lastCall.args[1]).to.equal(0)
+        expect(renderedComponent.state.show).to.be.false
+        done()
+    }, 500)
+  });
+});


### PR DESCRIPTION
For #9

I added some "starting" tests using mocha (with chai, jsdom, sinon and React's TestUtils).

It's difficult to test this without some changes to how it works. Tests need to be considered while you are writing the component for it to be easy to fully test something.

I included 3 tests here, one to ensure it starts out hidden, that it shows up when the page is scrolled, and that it scrolls back to the top when clicked.

It may seem like a lot of "tools" for testing, but each one is small and has one purpose. Let me know if you want to know anything about why I chose what I did, or what something does.

Also, I upgraded Babel to version 6. If you don't want this let me know and I can undo it, but I couldn't remember how to get mocha working with the older babel (it's possible, I just didn't want to look it up).