### PR TITLE
fix require of detect-passive-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.2.1]
+
+* **Bugfix:** fix require of detect-passive-events
+
 # [1.2.0]
 
 * **Performance:** use of passive listeners to improve scrolling performance

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 var React = require('react');
 var TweenFunctions = require('tween-functions');
 var objectAssign = require('object-assign');
-var detectPassiveEvents = require('detect-passive-events');
+var detectPassiveEvents = require('detect-passive-events').default;
 
 var ScrollUp = React.createClass({
     displayName: 'ScrollUp',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scroll-up",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React component to render element for scroll to top of page",
   "author": "Milos Janda <milos.janda@gmail.com>",
   "scripts": {

--- a/scrollUp.jsx
+++ b/scrollUp.jsx
@@ -8,7 +8,7 @@
 var React = require('react');
 var TweenFunctions = require('tween-functions');
 var objectAssign = require('object-assign');
-var detectPassiveEvents = require('detect-passive-events');
+var detectPassiveEvents = require('detect-passive-events').default;
 
 var ScrollUp = React.createClass({
 


### PR DESCRIPTION
we should use either
```
var detectPassiveEvents = require('detect-passive-events').default;
```
or
```
import detectPassiveEvents from 'detect-passive-events';
```

more details [here](http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default)