### PR TITLE
Prevent default on click

### DIFF
--- a/scrollUp.jsx
+++ b/scrollUp.jsx
@@ -76,7 +76,8 @@ var ScrollUp = React.createClass({
             this.setState({show: false});
         }
     },
-    handleClick: function () {
+    handleClick: function (e) {
+        e.preventDefault();
         this.stopScrolling();
         this.data.startValue = window.pageYOffset;
         this.data.currentTime = 0;


### PR DESCRIPTION
Hi

I'm using FloatingActionButton of material-ui into ScrollToTop component as child component. 
FloatingActionButton needs to set a href attribute. If I don't set It become gray color at default.
However I set `#` to a href attribute then becomes strange animation.
It only move to top animation so I would like to stop default event propagation of ScrollToTop.