### PR TITLE
Use create-react-class to avoid deprecation warnings in React 15.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,9 @@ var React = require('react');
 var TweenFunctions = require('tween-functions');
 var objectAssign = require('object-assign');
 var detectPassiveEvents = require('detect-passive-events').default;
+var createReactClass = require('create-react-class');
 
-var ScrollUp = React.createClass({
-    displayName: 'ScrollUp',
-
+var ScrollUp = createReactClass({
 
     data: {
         startValue: 0,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "detect-passive-events": "^1.0.0",
     "object-assign": "^4.0.1",
     "tween-functions": "^1.1.0"

--- a/scrollUp.jsx
+++ b/scrollUp.jsx
@@ -9,8 +9,9 @@ var React = require('react');
 var TweenFunctions = require('tween-functions');
 var objectAssign = require('object-assign');
 var detectPassiveEvents = require('detect-passive-events').default;
+var createReactClass = require('create-react-class');
 
-var ScrollUp = React.createClass({
+var ScrollUp = createReactClass({
 
     data: {
         startValue: 0,


### PR DESCRIPTION
As of React 15.5, a deprecation warning is given when `React.createClass` is used. It is advised to use the `create-react-class` package instead.