### PR TITLE
Update React version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tween-functions": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "0.13 - 15"
+    "react": "0.13 - ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",


### PR DESCRIPTION
This library seems to work fine in React v16, but npm gives a warning in the console when installing. Not a big deal, I know, just like to have clean output in my console ;) 
This PR updates the peerDependencies value in the package.json file to allow React v16.